### PR TITLE
Add 'black' formatter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: 'test'
+
+on: [ push, pull_request ]
+
+env:
+  CI: true
+  # https://github.com/tox-dev/tox/issues/1468
+  PY_COLORS: 1
+
+jobs:
+
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: install dependencies
+      run: |
+        pip install -U pip --progress-bar off
+        pip install -U virtualenv tox --progress-bar off
+    - name: run 'black'
+      run: tox -e py37-fmt -- --check

--- a/setup.py
+++ b/setup.py
@@ -34,16 +34,23 @@
 # ============================================================================
 #
 import setuptools
+from os.path import join, dirname, isfile
 
 with open("README.md", "r") as file:
-	long_description = file.read()
-
-requirements = []
-with open("requirements.txt") as file:
-	for line in file.readlines():
-		requirements.append(line)
+    long_description = file.read()
 
 projectName = "pyVHDLParser"
+
+rfile = "requirements.txt"
+if not isfile(rfile):
+	rfile = join(dirname(__file__), projectName + ".egg-info", "requires.txt")
+	if not isfile(rfile):
+		exit(1)
+
+requirements = []
+with open(rfile) as file:
+	for line in file.readlines():
+		requirements.append(line)
 
 github_url =  "https://github.com/Paebbels/" + projectName
 rtd_url =     "https://" + projectName + ".readthedocs.io/en/latest/"

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@
 # ============================================================================
 #
 import setuptools
-from pathlib import Path, PurePath
+from pathlib import Path
 
 with open("README.md", "r") as file:
 	long_description = file.read()
@@ -42,14 +42,14 @@ with open("README.md", "r") as file:
 projectName = "pyVHDLParser"
 
 rfile = Path("requirements.txt")
-root = PurePath(__file__)
-if not Path.is_file(rfile):
-	rfile = Path(root.parent, projectName + ".egg-info", "requires.txt")
-	if not Path.is_file(rfile):
+root = Path(__file__)
+if not rfile.is_file():
+	rfile = root.parent / (projectName + ".egg-info") / "requires.txt"
+	if not rfile.is_file():
 		exit(1)
 
 requirements = []
-with open(rfile) as file:
+with rfile.open() as file:
 	for line in file.readlines():
 		requirements.append(line)
 

--- a/setup.py
+++ b/setup.py
@@ -34,17 +34,18 @@
 # ============================================================================
 #
 import setuptools
-from os.path import join, dirname, isfile
+from pathlib import Path, PurePath
 
 with open("README.md", "r") as file:
 	long_description = file.read()
 
 projectName = "pyVHDLParser"
 
-rfile = "requirements.txt"
-if not isfile(rfile):
-	rfile = join(dirname(__file__), projectName + ".egg-info", "requires.txt")
-	if not isfile(rfile):
+rfile = Path("requirements.txt")
+root = PurePath(__file__)
+if not Path.is_file(rfile):
+	rfile = Path(root.parent, projectName + ".egg-info", "requires.txt")
+	if not Path.is_file(rfile):
 		exit(1)
 
 requirements = []

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ import setuptools
 from os.path import join, dirname, isfile
 
 with open("README.md", "r") as file:
-    long_description = file.read()
+	long_description = file.read()
 
 projectName = "pyVHDLParser"
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist = py{36,37,38}-fmt
+skip_missing_interpreters = True
+
+[testenv]
+recreate=True
+
+deps=
+    fmt: black
+
+commands=
+    fmt: {envpython} -m black ./ {posargs}


### PR DESCRIPTION
Close #7

This PR is a proposal to use [psf/black](https://github.com/psf/black) as the formatter for this project. It includes a `tox` configuration file and a GitHub Actions workflow to check the format after each push/PR.

Note that I did not format the code. This can be done with `tox -e py37-fmt`.

Currently, there is an error when installing this package. See https://github.com/eine/pyVHDLParser/runs/380246563

FTR, see related discussion in VUnit: VUnit/vunit#554