### PR TITLE
Add egg-info to .gitignore (w.r.t. pip install -e ...)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 
 # Python installation packages
 dist/
+/*.egg-info
 
 # Coverage.py
 .coverage


### PR DESCRIPTION
This line is set in pyVHDLModel .gitignore but not in this repo.
It's useful when using `pip install -e pyVHDLParser`