### PR TITLE
CLI bugfixes

### DIFF
--- a/pyVHDLParser/CLI/__init__.py
+++ b/pyVHDLParser/CLI/__init__.py
@@ -25,8 +25,9 @@ from typing                           import Protocol, Callable, Dict
 from pyAttributes                     import Attribute
 from pyAttributes.ArgParseAttributes  import ArgumentAttribute, SwitchArgumentAttribute
 
-from pyVHDLParser.Token               import LinebreakToken, IndentationToken, CommentToken, StringLiteralToken
-from pyVHDLParser.Token               import IntegerLiteralToken, WordToken, Token, SpaceToken, CharacterToken
+from pyVHDLParser.Token               import (LinebreakToken, IndentationToken, CommentToken, StringLiteralToken,
+											  IntegerLiteralToken, WordToken, SpaceToken, CharacterToken)
+from pyVHDLParser.Token               import Token as BaseToken
 from pyVHDLParser.Token.Keywords      import KeywordToken
 
 
@@ -76,8 +77,8 @@ TOKENTYPE_TO_COLOR_TRANSLATION = {
 }
 
 
-def translate(token: Token) -> str:
-	if isinstance(token, Token):
+def translate(token: BaseToken) -> str:
+	if isinstance(token, BaseToken):
 		tokenCls = token.__class__
 	else:
 		tokenCls = token

--- a/pyVHDLParser/DocumentModel/Reference/__init__.py
+++ b/pyVHDLParser/DocumentModel/Reference/__init__.py
@@ -26,7 +26,7 @@
 # ==============================================================================
 #
 # load dependencies
-from pyVHDLModel.VHDLModel                  import LibraryReference as LibraryReferenceModel, PackageReference as UseModel
+from pyVHDLModel.VHDLModel                  import Library as LibraryReferenceModel, Package as UseModel
 
 from pyVHDLParser.Token.Keywords            import IdentifierToken, AllKeyword
 from pyVHDLParser.Blocks                    import BlockParserException


### PR DESCRIPTION
I was not able to run the CLI due to some import errors.

First: It seems that LibraryReference and PackageReference have been renamed.

Second, it was a bit trickier. I didnt know that doing:
`from pyVHDLParser.CLI.Token import TokenStreamHandlers`
in VHDLParser.py stores a variable named `Token` in pyVHDLParser.CLI.\_\_init\_\_.py
Thus, Token class previously imported is hidden by the Token module in this \_\_init\_\_.py file which lead to `isinstance` raising an error:
`TypeError: isinstance() arg 2 must be a type or tuple of types`