### PR TITLE
Avoid tokenizer exception when parsing VHDL attributes

### DIFF
--- a/pyVHDLParser/Token/Parser.py
+++ b/pyVHDLParser/Token/Parser.py
@@ -353,7 +353,7 @@ class Tokenizer:
 
 					start.Column +=   1
 					start.Absolute += 1
-					buffer =          buffer[:2]
+					buffer =          buffer[1:]
 					if (buffer[0] in __ALPHA_CHARACTERS__) and (buffer[1] in __ALPHA_CHARACTERS__):
 						tokenKind =     cls.TokenKind.AlphaChars
 					elif (buffer[0] in __WHITESPACE_CHARACTERS__) and (buffer[1] in __WHITESPACE_CHARACTERS__):

--- a/pyVHDLParser/Token/__init__.py
+++ b/pyVHDLParser/Token/__init__.py
@@ -27,7 +27,7 @@
 # limitations under the License.                                                                                       #
 # ==================================================================================================================== #
 #
-from typing                   import Iterator, Optional as Nullable
+from typing                   import Iterator, Union, Optional as Nullable
 
 from pyTooling.Decorators     import export
 from pyTooling.MetaClasses    import ExtendedType
@@ -391,29 +391,33 @@ class ValuedToken(Token):
 		"""
 		return iter(self.Value)
 
-	def __eq__(self, other: str) -> bool:
+	def __eq__(self, other: Union[str, "ValuedToken"]) -> bool:
 		"""
 		Returns true, if the token's internal value is equal to the second operand.
 
 		:param other:      Parameter to compare against.
 		:returns:          ``True``, if token's value and second operand are equal.
-		:raises TypeError: If second operand is not of type :py:class:`str`.
+		:raises TypeError: If second operand is not of type :py:class:`str` or :py:class:`ValuedToken`.
 		"""
 		if isinstance(other, str):
 			return self.Value == other
+		elif isinstance(other, ValuedToken):
+			return self.Value == other.Value
 		else:
 			raise TypeError(f"Second operand of type '{other.__class__.__name__}' is not supported by equal operator.")
 
-	def __ne__(self, other: str) -> bool:
+	def __ne__(self, other: Union[str, "ValuedToken"]) -> bool:
 		"""
 		Returns true, if the token's internal value is unequal to the second operand.
 
 		:param other:      Parameter to compare against.
 		:returns:          ``True``, if token's value and second operand are unequal.
-		:raises TypeError: If second operand is not of type :py:class:`str`.
+		:raises TypeError: If second operand is not of type :py:class:`str` or :py:class:`ValuedToken`.
 		"""
 		if isinstance(other, str):
 			return self.Value != other
+		elif isinstance(other, ValuedToken):
+			return self.Value != other.Value
 		else:
 			raise TypeError(f"Second operand of type '{other.__class__.__name__}' is not supported by unequal operator.")
 

--- a/tests/issue/18/Issue_18.py
+++ b/tests/issue/18/Issue_18.py
@@ -39,7 +39,6 @@ if __name__ == "__main__":  # pragma: no cover
 	exit(1)
 
 class Issue_18(TestCase, SingleFileIssue):
-	@mark.xfail
 	def test_Tokenizer(self):
 		file = Path(__file__).with_suffix(".vhdl")
 		self.check_Tokenizer(file)

--- a/tests/unit/Tokenizer/Tokens.py
+++ b/tests/unit/Tokenizer/Tokens.py
@@ -256,6 +256,51 @@ class Sequence_5(TestCase, ExpectedDataMixin, TokenSequence):
          ]
 	)
 
+class Sequence_6(TestCase, ExpectedDataMixin, TokenSequence):
+	code = """if Clk'event and Clk = '1' then     -- rising clock edge\nname'attr1'attr2\nsignal reg_catch1   : std_logic_vector(flags_src1'range);"""
+	tokenStream = ExpectedTokenStream(
+		[ (StartOfDocumentToken,   None),
+			(WordToken,               "if"),
+			(WhitespaceToken,         " "),
+			(WordToken,               "Clk"),
+			(CharacterToken,          "'"),
+			(WordToken,               "event"),
+			(WhitespaceToken,         " "),
+			(WordToken,               "and"),
+			(WhitespaceToken,         " "),
+			(WordToken,               "Clk"),
+			(WhitespaceToken,         " "),
+			(CharacterToken,          "="),
+			(WhitespaceToken,         " "),
+			(CharacterLiteralToken,   "1"),
+			(WhitespaceToken,         " "),
+			(WordToken,               "then"),
+			(WhitespaceToken,         "     "),
+			(SingleLineCommentToken,  "-- rising clock edge\n"),
+			(WordToken,               "name"),
+			(CharacterToken,          "'"),
+			(WordToken,               "attr1"),
+			(CharacterToken,          "'"),
+			(WordToken,               "attr2"),
+			(LinebreakToken,          None),
+			(WordToken,               "signal"),
+			(WhitespaceToken,         " "),
+			(WordToken,               "reg_catch1"),
+			(WhitespaceToken,         "   "),
+			(CharacterToken,          ":"),
+			(WhitespaceToken,         " "),
+			(WordToken,               "std_logic_vector"),
+			(CharacterToken,          "("),
+			(WordToken,               "flags_src1"),
+			(CharacterToken,          "'"),
+			(WordToken,               "range"),
+			(CharacterToken,          ")"),
+			(CharacterToken,          ";"),
+			(EndOfDocumentToken,     None)
+		]
+	)
+
+
 class Tokenizer_ExceptionInKeyword(TestCase, ExpectedDataMixin, TokenSequence):
 	code = """keyword"""
 	tokenStream = ExpectedTokenStream(


### PR DESCRIPTION
Since I also ran into the problem described by #4 and #18, I went ahead and applied the fix of #26.

An additional testcase in Tokens.py should catch regressions.


PS: While running the tests using pytest, a completely independent testcase failed for me. Seems like you commented the code on purpose. Maybe it was a mistake?