### PR TITLE
Disambiguate between context declarations and context references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ coverage.xml
 /.idea/workspace.xml
 
 pyVHDLParser/Sven
+venv/

--- a/pyVHDLParser/Blocks/InterfaceObject.py
+++ b/pyVHDLParser/Blocks/InterfaceObject.py
@@ -259,14 +259,14 @@ class InterfaceObjectBlock(Block):
 			return
 		elif isinstance(token, CharacterToken):
 			if token == '(':
-			# 	parserState.NewToken = BoundaryToken(fromExistingToken=token)
-			# 	parserState.NewBlock = cls(parserState.LastBlock, parserState.TokenMarker,
-			# 														 endToken=parserState.NewToken.PreviousToken)
-			# 	parserState.TokenMarker = parserState.NewToken
-			# 	parserState.NextState = LoopBlock.stateSequentialRegion
-			# 	parserState.PushState = ExpressionBlockEndedByLoopORToORDownto.stateExpression
-			# 	return
-			# elif token == ';':
+				parserState.NewToken = BoundaryToken(fromExistingToken=token)
+				parserState.NewBlock = cls(parserState.LastBlock, parserState.TokenMarker,
+																	 endToken=parserState.NewToken.PreviousToken)
+				parserState.TokenMarker = parserState.NewToken
+				parserState.NextState = LoopBlock.stateSequentialRegion
+				parserState.PushState = ExpressionBlockEndedByLoopORToORDownto.stateExpression
+				return
+			elif token == ';':
 				parserState.NewToken =    DelimiterToken(fromExistingToken=token)
 				parserState.NewBlock =    cls(parserState.LastBlock, parserState.TokenMarker, endToken=parserState.NewToken.PreviousToken)
 				_ =                       cls.DELIMITER_BLOCK(parserState.NewBlock, parserState.NewToken)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ py-flags>=1.1.4
 
 pyTooling >= 5.0.0, <6.0
 pyAttributes>=2.5.1
-pyVHDLModel==0.25.1
+pyVHDLModel==0.27.1

--- a/tests/unit/Common.py
+++ b/tests/unit/Common.py
@@ -184,7 +184,7 @@ class BlockSequence(ITestcase): #, ExpectedDataMixin):
 
 				self.assertIsInstance(
 					block, item[0],
-				  msg=f"Block has not expected type.\n  Actual:   {block!s}\n  Expected: {item[0].__qualname__}"
+				  msg=f"Block has not expected type.\n  Actual:   {type(block).__qualname__}\n  Expected: {item[0].__qualname__}"
 				)
 				if item[1] is not None:
 					blockValue = str(block)

--- a/tests/unit/SimpleBlockSequences/Context.py
+++ b/tests/unit/SimpleBlockSequences/Context.py
@@ -29,10 +29,11 @@
 #
 from unittest                       import TestCase
 
-from pyVHDLParser.Blocks.Whitespace     import WhitespaceBlock
-from pyVHDLParser.Blocks.Reference  import Use, Context
-from pyVHDLParser.Token             import WordToken, StartOfDocumentToken, WhitespaceToken, CharacterToken, EndOfDocumentToken
-from pyVHDLParser.Blocks            import StartOfDocumentBlock, EndOfDocumentBlock
+from pyVHDLParser.Blocks.Whitespace import WhitespaceBlock
+from pyVHDLParser.Blocks.Reference  import Context, Use, Library
+from pyVHDLParser.Token             import WordToken, StartOfDocumentToken, WhitespaceToken, CharacterToken, EndOfDocumentToken, SingleLineCommentToken, MultiLineCommentToken, IndentationToken, LinebreakToken
+from pyVHDLParser.Blocks            import StartOfDocumentBlock, EndOfDocumentBlock, CommentBlock
+from pyVHDLParser.Blocks.Whitespace import IndentationBlock, LinebreakBlock
 
 from tests.unit.Common              import Initializer, ExpectedDataMixin, LinkingTests, TokenSequence, BlockSequence, ExpectedTokenStream, ExpectedBlockStream
 
@@ -44,9 +45,9 @@ if __name__ == "__main__":  # pragma: no cover
 
 
 def setUpModule():
-	i = Initializer()
+	_ = Initializer()
 
-class Library_OneLine_SingleLibrary(TestCase, ExpectedDataMixin, LinkingTests, TokenSequence, BlockSequence):
+class Context_OneLine_SingleLibrary(TestCase, ExpectedDataMixin, LinkingTests, TokenSequence, BlockSequence):
 	code = "context ctx is use lib0.pkg0.all; end context;"
 	tokenStream = ExpectedTokenStream(
 		[ (StartOfDocumentToken, None),
@@ -74,13 +75,282 @@ class Library_OneLine_SingleLibrary(TestCase, ExpectedDataMixin, LinkingTests, T
 	)
 	blockStream = ExpectedBlockStream(
 		[ (StartOfDocumentBlock, None),                  #
-			(Context.NameBlock,         "context ctx is"), #
-			(WhitespaceBlock,           " "),
-			(Use.StartBlock,            "use "),           # use
-			(Use.ReferenceNameBlock,    "lib0.pkg0.all"),  # lib0.pkg0.all
-			(Use.EndBlock,              ";"),              # ;
-			(WhitespaceBlock,           " "),
-			(Context.EndBlock,          "end context;"),
-			(EndOfDocumentBlock,        None)              #
+			(Context.DeclarationStartBlock,  "context"), #
+			(WhitespaceBlock,                " "),
+			(Context.DeclarationStartBlock,  "ctx"), #
+			(WhitespaceBlock,                " "),
+			(Context.DeclarationStartBlock,  "is"), #
+			(WhitespaceBlock,                " "),
+			(Use.StartBlock,                 "use "),           # use
+			(Use.ReferenceNameBlock,         "lib0.pkg0.all"),  # lib0.pkg0.all
+			(Use.EndBlock,                   ";"),              # ;
+			(WhitespaceBlock,                " "),
+			(Context.DeclarationEndBlock,    "end context;"),
+			(EndOfDocumentBlock,             None)              #
+		]
+	)
+
+class Context_SingleLibrary_Whitespaces(TestCase, ExpectedDataMixin, LinkingTests, TokenSequence, BlockSequence):
+	code = "context --test1\n ctx is use lib0.pkg0.all; end  --test\ncontext /**/;"
+	tokenStream = ExpectedTokenStream(
+		[ (StartOfDocumentToken, None),
+			(WordToken,            "context"),
+			(WhitespaceToken, " "),
+			(SingleLineCommentToken, "--test1\n"),
+			(IndentationToken, " "),
+			(WordToken,            "ctx"),
+			(WhitespaceToken, " "),
+			(WordToken,            "is"),
+			(WhitespaceToken, " "),
+			(WordToken,            "use"),
+			(WhitespaceToken, " "),
+			(WordToken,            "lib0"),
+			(CharacterToken,       "."),
+			(WordToken,            "pkg0"),
+			(CharacterToken,       "."),
+			(WordToken,            "all"),
+			(CharacterToken,       ";"),
+			(WhitespaceToken, " "),
+			(WordToken,            "end"),
+			(WhitespaceToken, "  "),
+			(SingleLineCommentToken, "--test\n"),
+			(WordToken,            "context"),
+			(WhitespaceToken, " "),
+			(MultiLineCommentToken, "/**/"),
+			(CharacterToken,       ";"),
+			(EndOfDocumentToken,   None)
+		]
+	)
+	blockStream = ExpectedBlockStream(
+		[ (StartOfDocumentBlock, None),
+			(Context.DeclarationStartBlock,  "context"),
+			(WhitespaceBlock,                " "),
+			(CommentBlock,                   "--test1\n"),
+			(IndentationBlock,               " "),
+			(Context.DeclarationStartBlock,  "ctx"),
+			(WhitespaceBlock,                " "),
+			(Context.DeclarationStartBlock,  "is"),
+			(WhitespaceBlock,                " "),
+			(Use.StartBlock,                 "use "),           # use
+			(Use.ReferenceNameBlock,         "lib0.pkg0.all"),  # lib0.pkg0.all
+			(Use.EndBlock,                   ";"),              # ;
+			(WhitespaceBlock,                " "),
+			(Context.DeclarationEndBlock,    "end  "),
+			(CommentBlock,                   "--test\n"),
+			(Context.DeclarationEndBlock,    "context "),
+			(CommentBlock,                   "/**/"),
+			(Context.DeclarationEndBlock,    ";"),
+			(EndOfDocumentBlock,             None)              #
+		]
+	)
+
+class Context_OneLine_Single_SimpleReference(TestCase, ExpectedDataMixin, LinkingTests, TokenSequence, BlockSequence):
+	code = "context ctx;"
+	tokenStream = ExpectedTokenStream(
+		[ (StartOfDocumentToken, None),
+			(WordToken,             "context"),
+			(WhitespaceToken,       " "),
+			(WordToken,             "ctx"),
+			(CharacterToken,        ";"),
+			(EndOfDocumentToken,   None)
+		]
+	)
+	blockStream = ExpectedBlockStream(
+		[ (StartOfDocumentBlock, None),                  #
+			(Context.ReferenceStartBlock, "context"), #
+			(WhitespaceBlock,             " "),
+			(Context.ReferenceNameBlock,  "ctx"), #
+			(Context.ReferenceEndBlock,   ";"), #
+			(EndOfDocumentBlock,     None)              #
+		]
+	)
+
+
+class Context_OneLine_Single_Reference(TestCase, ExpectedDataMixin, LinkingTests, TokenSequence, BlockSequence):
+	code = "context lib.ctx;"
+	tokenStream = ExpectedTokenStream(
+		[ (StartOfDocumentToken, None),
+			(WordToken,             "context"),
+			(WhitespaceToken,       " "),
+			(WordToken,             "lib"),
+			(CharacterToken,        "."),
+			(WordToken,             "ctx"),
+			(CharacterToken,        ";"),
+			(EndOfDocumentToken,   None)
+		]
+	)
+	blockStream = ExpectedBlockStream(
+		[ (StartOfDocumentBlock, None),                  #
+			(Context.ReferenceStartBlock, "context"),
+			(WhitespaceBlock,             " "),
+			(Context.ReferenceNameBlock,  "lib.ctx"),
+			(Context.ReferenceEndBlock,   ";"),
+			(EndOfDocumentBlock,     None)
+		]
+	)
+
+
+class Context_OneLine_Multiple_References(TestCase, ExpectedDataMixin, LinkingTests, TokenSequence, BlockSequence):
+	code = "context lib.ctx,ctx2,xil_defaultlib.ctx3;"
+	tokenStream = ExpectedTokenStream(
+		[ (StartOfDocumentToken, None),
+			(WordToken,             "context"),
+			(WhitespaceToken,       " "),
+			(WordToken,             "lib"),
+			(CharacterToken,        "."),
+			(WordToken,             "ctx"),
+			(CharacterToken,        ","),
+			(WordToken,             "ctx2"),
+			(CharacterToken,        ","),
+			(WordToken,             "xil_defaultlib"),
+			(CharacterToken,        "."),
+			(WordToken,             "ctx3"),
+			(CharacterToken,        ";"),
+			(EndOfDocumentToken,   None)
+		]
+	)
+	blockStream = ExpectedBlockStream(
+		[ (StartOfDocumentBlock, None),
+			(Context.ReferenceStartBlock, "context"),
+			(WhitespaceBlock,             " "),
+			(Context.ReferenceNameBlock,  "lib.ctx"),
+			(Context.DelimiterBlock,      ","),
+			(Context.ReferenceNameBlock,  "ctx2"),
+			(Context.DelimiterBlock,      ","),
+			(Context.ReferenceNameBlock,  "xil_defaultlib.ctx3"),
+			(Context.ReferenceEndBlock,  ";"),
+			(EndOfDocumentBlock,     None)
+		]
+	)
+
+class Context_OneLine_Multiple_References2(TestCase, ExpectedDataMixin, LinkingTests, TokenSequence, BlockSequence):
+	code = "context lib.ctx,ctx2,ctx3;"
+	tokenStream = ExpectedTokenStream(
+		[ (StartOfDocumentToken, None),
+			(WordToken,             "context"),
+			(WhitespaceToken,       " "),
+			(WordToken,             "lib"),
+			(CharacterToken,        "."),
+			(WordToken,             "ctx"),
+			(CharacterToken,        ","),
+			(WordToken,             "ctx2"),
+			(CharacterToken,        ","),
+			(WordToken,             "ctx3"),
+			(CharacterToken,        ";"),
+			(EndOfDocumentToken,   None)
+		]
+	)
+	blockStream = ExpectedBlockStream(
+		[ (StartOfDocumentBlock, None),                  #
+			(Context.ReferenceStartBlock, "context"),
+			(WhitespaceBlock,             " "),
+			(Context.ReferenceNameBlock,  "lib.ctx"),
+			(Context.DelimiterBlock,      ","),
+			(Context.ReferenceNameBlock,  "ctx2"),
+			(Context.DelimiterBlock,      ","),
+			(Context.ReferenceNameBlock,  "ctx3"),
+			(Context.ReferenceEndBlock,  ";"),
+			(EndOfDocumentBlock,     None)
+		]
+	)
+
+
+class Context_Multiline_Multiple_Libraries_And_Contexts(TestCase, ExpectedDataMixin, LinkingTests, TokenSequence, BlockSequence):
+	code = """
+context ctx_name is
+   library ieee;
+   use ieee.numeric_std.all;
+
+   -- Include another context
+   library xil_defaultlib;
+   context xil_defaultlib.my_ctx;
+end context;
+"""
+	tokenStream = ExpectedTokenStream(
+		[ (StartOfDocumentToken, None),
+			(LinebreakToken,        None),
+			(WordToken,             "context"),
+			(WhitespaceToken,       " "),
+			(WordToken,             "ctx_name"),
+			(WhitespaceToken,       " "),
+			(WordToken,             "is"),
+			(LinebreakToken,        None),
+			(IndentationToken,      "   "),
+			(WordToken,             "library"),
+			(WhitespaceToken,       " "),
+			(WordToken,             "ieee"),
+			(CharacterToken,        ";"),
+			(LinebreakToken,        None),
+			(IndentationToken,      "   "),
+			(WordToken,             "use"),
+			(WhitespaceToken,       " "),
+			(WordToken,             "ieee"),
+			(CharacterToken,        "."),
+			(WordToken,             "numeric_std"),
+			(CharacterToken,        "."),
+			(WordToken,             "all"),
+			(CharacterToken,        ";"),
+			(LinebreakToken,        None),
+			(LinebreakToken,        None),
+			(IndentationToken,      "   "),
+			(SingleLineCommentToken, "-- Include another context\n"),
+			(IndentationToken,      "   "),
+			(WordToken,             "library"),
+			(WhitespaceToken,       " "),
+			(WordToken,             "xil_defaultlib"),
+			(CharacterToken,        ";"),
+			(LinebreakToken,        None),
+			(IndentationToken,      "   "),
+			(WordToken,             "context"),
+			(WhitespaceToken,       " "),
+			(WordToken,             "xil_defaultlib"),
+			(CharacterToken,        "."),
+			(WordToken,             "my_ctx"),
+			(CharacterToken,        ";"),
+			(LinebreakToken,        None),
+			(WordToken,             "end"),
+			(WhitespaceToken,       " "),
+			(WordToken,             "context"),
+			(CharacterToken,        ";"),
+			(LinebreakToken,        None),
+			(EndOfDocumentToken,   None)
+		]
+	)
+	blockStream = ExpectedBlockStream(
+		[ (StartOfDocumentBlock, None),                  #
+			(LinebreakBlock,               None),
+			(Context.DeclarationStartBlock, "context"),
+			(WhitespaceBlock,               " "),
+			(Context.DeclarationStartBlock, "ctx_name"),
+			(WhitespaceBlock,               " "),
+			(Context.DeclarationStartBlock, "is"),
+			(LinebreakBlock,               None),
+			(IndentationBlock,             "   "),
+			(Library.StartBlock,           "library "),
+			(Library.LibraryNameBlock,     "ieee"),
+			(Library.EndBlock,             ";"),
+			(LinebreakBlock,               None),
+			(IndentationBlock,             "   "),
+			(Use.StartBlock,               "use "),
+			(Use.ReferenceNameBlock,       "ieee.numeric_std.all"),
+			(Use.EndBlock,                 ";"),
+			(LinebreakBlock,               None),
+			(LinebreakBlock,               None),
+			(IndentationBlock,             "   "),
+			(CommentBlock,                 "-- Include another context\n"),
+			(IndentationBlock,             "   "),
+			(Library.StartBlock,           "library "),
+			(Library.LibraryNameBlock,     "xil_defaultlib"),
+			(Library.EndBlock,             ";"),
+			(LinebreakBlock,               None),
+			(IndentationBlock,             "   "),
+			(Context.ReferenceStartBlock,  "context"),
+			(WhitespaceBlock,              " "),
+			(Context.ReferenceNameBlock,   "xil_defaultlib.my_ctx"),
+			(Context.ReferenceEndBlock,    ";"),
+			(LinebreakBlock,               None),
+			(Context.DeclarationEndBlock,  "end context;"), #
+			(LinebreakBlock,               None),
+			(EndOfDocumentBlock,     None)              #
 		]
 	)


### PR DESCRIPTION
This pull request fixes #16, among other things.

The `context` keyword is used for context declarations (which were already implemented) and context references (which were still missing). To disambiguate between these two (and to avoid having to deal with this issue at a higher level again), I implemented a lookahead mechanism.

`Context.StartBlock` contains a set of states which only check whether the token stream describes a context declaration, reference or neither. These states do not alter the tokens nor do they generate new blocks by themselves.
As soon as it is decideable, `Context.StartBlock` hands control over to either `Context.ReferenceStartBlock` or `Context.DeclarationStartBlock` respectively.

Since the `TokenToBlockParser` only supported looking at a token a single time, I created a second parser instance, which iterates over everything from `TokenMarker`  (which holds the `ContextKeyword` token) up to the current token. The method `TokenToBlockParser.ReparseFromTokenMarker` can be used to do exactly that.

I also implemented a parser method `TokenToBlockParser.HandleNonCodeTokens` which can create non-code blocks (i.e. all kinds of whitespaces and comments) since the LRM allows them basically everywhere. While the LRM does not technically list delimited comments (`/* ... */`) as separators (§15.3), they effectively act as separators insofar as they separate adjacent lexical elements. 

I would love to know your thoughts about these changes and if/how you want to integrate them!